### PR TITLE
Fixing ball getting caught in paddles #22

### DIFF
--- a/core/src/main/java/io/github/cpaech/charlie/Controller.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Controller.java
@@ -36,11 +36,13 @@ public class Controller {
         // Collision with Paddle A
         if (model.ball.overlaps(model.paddleA)) {
             model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+            model.ball.x = model.paddleA.x + model.paddleA.width;
         }
 
         // Collision with Paddle B
         if (model.ball.overlaps(model.paddleB)) {
             model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+            model.ball.x = model.paddleB.x - model.paddleB.width; // da beide Koordinatensysteme unten links angeordnet sind (Ball und Paddle).
         }
 
         // Collision with Decke/Boden (Spielfeldgrenzen)


### PR DESCRIPTION
Fixes #22 by how it's described in the issue; setting the balls x-position out of the paddle after the collision check/reversing x-speed has been done and the ball has been moved in this frame. However this leads to wired ball behavior when hitting the ball with the side of the paddle; the ball gets 'teleported' in front of the paddle.