### PR TITLE
Fixes Ball Collision / ball does no longer get stuck

### DIFF
--- a/core/src/main/java/io/github/cpaech/charlie/Model.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Model.java
@@ -13,6 +13,7 @@ public class Model {
     public Vector2 ballVelocity = new Vector2();
     public int scoreA = 0;
     public int scoreB = 0;
+    Vector2 tempBallPosition = new Vector2(0, 0); // Hier wird die Position des Balls bevor der Bewegung peichern, um diese bei einer Kollisionen zurückzusetzen.
     public int paddleSpeed = 300; // Geschwindigkeit der Paddles in Pixel pro Sekunde
     public float[] backgroundColor = {0.15f, 0.15f, 0.2f, 1f};
 }


### PR DESCRIPTION
Ball does no longer get stuck in any way i found. Fixes #54 not exactly how suggested, if we just invert the x speed and reset the position for every case in that which the ball was by some miniscule amount before the paddle, this will lead to some visually very wired collision. Collision is now set to the top of the paddle plus HALF (not the entirety of the ball) of the balls height and looks better. Still some wired collision edge cases because the speed can vary so widely.