### PR TITLE
Ball Collision - Neuer Ansatz

### DIFF
--- a/core/src/main/java/io/github/cpaech/charlie/Controller.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Controller.java
@@ -5,81 +5,90 @@ import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Rectangle;
 
+
+/**
+ * This is the Controller. It updates the gameStates and values 
+ * and is responsible for the game logic
+ */
 public class Controller {
+
+    /**
+     * Reference to the global model
+     */
     public Model model;
    
+    /**
+     * Initilizes the Controller and calls @see io.github.cpaech.charlie.Controller
+     * @param model Reference to the global model
+     * 
+    */
     public Controller(Model model) {
         this.model = model;
         modelwerteInitialisieren();
     }
-    public void render(float delta) {
-        // Update the game state based on user input and other factors
-        // For example, move paddles, update ball position, check for collisions, etc.
-        // This is where the game logic would go
-        // Verhalten im Unendlichen des Balles
 
-        if (model.ball.x + model.ball.width< 0) { // +width, damit der Ball komplett aus dem Spielfeld ist
-            model.scoreB++; // player B scores a point
-            resetBall();    // Ball zurücksetzen
+    /**
+    * Update the game state based on user input and other factors
+    * For example, move paddles, update ball position, check for collisions, etc.
+    * This is where the game logic would go
+    * @param delta This is the time in seconds since the last call to this method
+    */
+    public void render(float delta) {
+        
+        if (model.ball.x + model.ball.width < 0) { //check right side of ball against left wall of playingfield
+            model.scoreB++;
+            resetBall();
         }
         if (model.ball.x > model.screenWidth) {
-            model.scoreA++; // player A scores a point
-            resetBall();    // Ball zurücksetzen
+            model.scoreA++;
+            resetBall();
         }
 
-        model.tempBallPosition.set(model.ball.x, model.ball.y); // Speichern der Ballposition vor der Bewegung, um sie bei Kollisionen zurückzusetzen
-        // keeps the ball updated based on the delta time and the current velocity
-        // Delta is the time since the last frame, used for smooth movement
-        model.ball.x += model.ballVelocity.x * delta; // Ball in x-Richtung bewegen
-        model.ball.y += model.ballVelocity.y * delta; // Ball in y-Richtung bewegen
+        model.tempBallPosition.set(model.ball.x, model.ball.y); 
+        
+        model.ball.x += model.ballVelocity.x * delta;
+        model.ball.y += model.ballVelocity.y * delta;
 
-        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle berührt und ob der Ball sich in der Höhe des Paddles befindet. / 2 damit dieser Kollisionsfall nicht in extremfällen eintritt die bei einer niedrigen Renderrate Visuell sehr unwahrscheinlich erscheinen
-            model.lastCollidedPaddle = 1; // Paddle A ist das letzte Paddle, mit dem der Ball kollidiert ist
-            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { 
+            model.lastCollidedPaddle = 1; // Paddle A ist now lastCollidedPaddle
+            model.ballVelocity.x *= -1.0f; 
         }
-        if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle berührt und ob der Ball sich in der Höhe des Paddles befindet. / 2 damit dieser Kollisionsfall nicht in extremfällen eintritt die bei einer niedrigen Renderrate Visuell sehr unwahrscheinlich erscheinen
-            model.lastCollidedPaddle = 2; // Paddle B ist das letzte Paddle, mit dem der Ball kollidiert ist
-            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+        if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) { 
+            model.lastCollidedPaddle = 2; // Paddle B is now the lastCollidedPaddle
+            model.ballVelocity.x *= -1.0f; 
         }
-        inputHandling(); // Eingaben verarbeiten
-        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle A berührt
-            model.lastCollidedPaddle = 1; // Paddle A ist das letzte Paddle, mit dem der Ball kollidiert ist
-            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
-            model.ball.x = model.paddleA.x + model.paddleA.width; // Ball auf die rechte Seite des Paddles setzen, damit er nicht in der Wand bleibt
+
+        inputHandling(); //PaddleMovement
+
+        //Collisionchecks if the Paddle moved into the Ball
+        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { 
+            model.lastCollidedPaddle = 1; // Paddle A is now lastCollidedPaddle
+            model.ballVelocity.x *= -1.0f; 
+            model.ball.x = model.paddleA.x + model.paddleA.width; //Move in front of Paddle
         }
-        else if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle A berührt
-            model.lastCollidedPaddle = 2; // Paddle B ist das letzte Paddle, mit dem der Ball kollidiert ist
-            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
-            model.ball.x = model.paddleB.x - model.ball.width; // Ball auf die rechte Seite des Paddles setzen, damit er nicht in der Wand bleibt
+        else if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) {
+            model.lastCollidedPaddle = 2; // Paddle B is now the lastCollidedPaddle
+            model.ballVelocity.x *= -1.0f; 
+            model.ball.x = model.paddleB.x - model.ball.width; // Move in front of Paddle
         }
-        // Collision with Decke/Boden (Spielfeldgrenzen)
-        if (model.ball.y <= 0 || model.ball.y + model.ball.height >= model.screenHeight) { // || steht für ODER, eins von beidem muss wahr sein
-        // Wenn der Ball die obere oder untere Grenze des Spielfelds berührt, kehre die y-Richtung um
+
+        // Collision with top and bottom
+        if (model.ball.y <= 0 || model.ball.y + model.ball.height >= model.screenHeight) {
             model.ballVelocity.y *= -1.0f; // y-Richtung umkehren
-            model.ball.setY(model.tempBallPosition.y); // Ball zurücksetzen, damit er bei unterschiedliche delta-Werten nicht in der Wand bleibt
+            model.ball.setY(model.tempBallPosition.y); 
         }
     }
+
+    /**
+     * This method disposes of any allocated ressources like textures of fonts
+     */
     public void dispose() {
-        // Dispose of any resources that need to be cleaned up
-        // For example, textures, sounds, etc.
     }
 
-    public void isPaddleNowOverBall(Rectangle paddle, float delta) {
-        if(model.ball.overlaps(paddle)){                             // der Ball kann nun immernoch im Paddle sein, wenn man mit dem Paddle in den Ball hinein fährt und Ballgeschwindigkeit.y<Paddlegeschwindigkeit
-            if(model.ball.y < paddle.y + paddle.height / 2){         // Fallunterscheidung; ist man von oben/unten mit dem Paddle auf den Ball gefahren
-                model.ball.y = paddle.y - model.ball.height;         // da dies nur eintreten kann, wenn der Ball zu kleine Geschwindigkeit.y hat um selbst aus dem Paddle auszutreten/in das Paddle hinein fährt, schieben wir den Ball vor dem Paddle her
-                if(model.ballVelocity.y < 0.0f){                     // wenn der Ball auf die Untere Hälfte des Paddles trifft und sich nach unten bewegt, muss die Umdrehung der y-Richtung aus ballCollisionWithPaddle() rückgängig gemacht werden. Genauso für den Fall das der Ball auf die obere Hälfte des Paddles trifft und sich nach oben bewegt
-                    model.ballVelocity.y = -model.ballVelocity.y;
-                }
-            }else{
-                model.ball.y = paddle.y + paddle.height;
-                if(model.ballVelocity.y < 0.0f){
-                    model.ballVelocity.y = -model.ballVelocity.y;
-                }
-            }
-        }
-    }
-
+    /**
+     * This initializes values of the model
+     * For example paddle size or position
+     */
     public void modelwerteInitialisieren(){
         model.paddleA.setSize(20, 100);
         model.paddleB.setSize(20, 100);
@@ -88,15 +97,22 @@ public class Controller {
         model.ball.setSize(20, 20);
         model.scoreA = 0;
         model.scoreB = 0;
-        resetBall(); // Ball zurücksetzen
-    }
-    private void resetBall() {
-        model.lastCollidedPaddle = 0; // Letztes Paddle zurücksetzen, damit der Ball nicht sofort wieder zurückprallt
-        // Set the ball to the center of the screen and reset its velocity after a point is scored or the ball goes out of bounds
-        model.ball.setPosition(model.screenWidth/2, model.screenHeight/2);  // x,y Ball in die Mitte setzen
-        model.ballVelocity.set((float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f, (float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f + (float)Math.random() * 100.0f - 50.0f);  // Ballgeschwindigkeit zurücksetzen
+        resetBall();
     }
 
+    /**
+     * This resets the Ball to the middle of the screen
+     * and assigns it a random velocity
+     */
+    private void resetBall() {
+        model.lastCollidedPaddle = 0;
+        model.ball.setPosition(model.screenWidth/2, model.screenHeight/2);
+        model.ballVelocity.set((float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f, (float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f + (float)Math.random() * 100.0f - 50.0f); 
+    }
+
+    /**
+     * This moves the paddles up or down, based on userinput
+     */
     public void inputHandling()
     {
         boolean isPressedW = Gdx.input.isKeyPressed(Keys.W);
@@ -104,22 +120,22 @@ public class Controller {
         boolean isPressedUp = Gdx.input.isKeyPressed(Keys.UP);
         boolean isPressedDown = Gdx.input.isKeyPressed(Keys.DOWN);
         
-        model.paddleA.y += (isPressedW ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); // Paddle A nach oben bewegen
-        model.paddleA.y -= (isPressedS ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); // Paddle A nach unten bewegen
-        model.paddleB.y += (isPressedUp ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); // Paddle B nach oben bewegen
-        model.paddleB.y -= (isPressedDown ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); // Paddle B nach unten bewegen
-        // Ensure paddles stay within the bounds of the screen
+        model.paddleA.y += (isPressedW ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime();
+        model.paddleA.y -= (isPressedS ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); 
+        model.paddleB.y += (isPressedUp ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime(); 
+        model.paddleB.y -= (isPressedDown ? 1 : 0) * model.paddleSpeed * Gdx.graphics.getDeltaTime();
+        
         if (model.paddleA.y < 0) {
-            model.paddleA.y = 0; // Paddle A nicht unter den Bildschirm bewegen
+            model.paddleA.y = 0;
         }
         if (model.paddleA.y + model.paddleA.height > 600) {
-            model.paddleA.y = 600 - model.paddleA.height; // Paddle A nicht über den Bildschirm bewegen
+            model.paddleA.y = 600 - model.paddleA.height;
         }
         if (model.paddleB.y < 0) {
-            model.paddleB.y = 0; // Paddle B nicht unter den Bildschirm bewegen
+            model.paddleB.y = 0;
         }
         if (model.paddleB.y + model.paddleB.height > 600) {
-            model.paddleB.y = 600 - model.paddleB.height; // Paddle B nicht über den Bildschirm bewegen
+            model.paddleB.y = 600 - model.paddleB.height;
         }
     }
 }

--- a/core/src/main/java/io/github/cpaech/charlie/Controller.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Controller.java
@@ -33,16 +33,25 @@ public class Controller {
         model.ball.x += model.ballVelocity.x * delta; // Ball in x-Richtung bewegen
         model.ball.y += model.ballVelocity.y * delta; // Ball in y-Richtung bewegen
 
-        // Collision with Paddle A
-        ballCollisionWithPaddle(model.paddleA);
-        // Collision with Paddle B
-        ballCollisionWithPaddle(model.paddleB);
-
+        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle berührt und ob der Ball sich in der Höhe des Paddles befindet. / 2 damit dieser Kollisionsfall nicht in extremfällen eintritt die bei einer niedrigen Renderrate Visuell sehr unwahrscheinlich erscheinen
+            model.lastCollidedPaddle = 1; // Paddle A ist das letzte Paddle, mit dem der Ball kollidiert ist
+            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+        }
+        if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle berührt und ob der Ball sich in der Höhe des Paddles befindet. / 2 damit dieser Kollisionsfall nicht in extremfällen eintritt die bei einer niedrigen Renderrate Visuell sehr unwahrscheinlich erscheinen
+            model.lastCollidedPaddle = 2; // Paddle B ist das letzte Paddle, mit dem der Ball kollidiert ist
+            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+        }
         inputHandling(); // Eingaben verarbeiten
-
-        isPaddleNowOverBall(model.paddleA, delta);  // nachdem die Paddles bewegt wurden, prüfen ob der Ball im Paddle ist und ggf. die Ballposition und Geschwindigkeit anpassen
-        isPaddleNowOverBall(model.paddleB, delta);
-
+        if (model.ball.overlaps(model.paddleA) && (model.lastCollidedPaddle == 2 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle A berührt
+            model.lastCollidedPaddle = 1; // Paddle A ist das letzte Paddle, mit dem der Ball kollidiert ist
+            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+            model.ball.x = model.paddleA.x + model.paddleA.width; // Ball auf die rechte Seite des Paddles setzen, damit er nicht in der Wand bleibt
+        }
+        else if (model.ball.overlaps(model.paddleB) && (model.lastCollidedPaddle == 1 || model.lastCollidedPaddle == 0)) { // Überprüfen, ob der Ball das Paddle A berührt
+            model.lastCollidedPaddle = 2; // Paddle B ist das letzte Paddle, mit dem der Ball kollidiert ist
+            model.ballVelocity.x *= -1.0f; // x-Richtung umkehren
+            model.ball.x = model.paddleB.x - model.ball.width; // Ball auf die rechte Seite des Paddles setzen, damit er nicht in der Wand bleibt
+        }
         // Collision with Decke/Boden (Spielfeldgrenzen)
         if (model.ball.y <= 0 || model.ball.y + model.ball.height >= model.screenHeight) { // || steht für ODER, eins von beidem muss wahr sein
         // Wenn der Ball die obere oder untere Grenze des Spielfelds berührt, kehre die y-Richtung um
@@ -71,17 +80,6 @@ public class Controller {
         }
     }
 
-    public void ballCollisionWithPaddle(Rectangle paddle){
-        if (model.ball.overlaps(paddle) && paddle.y < model.tempBallPosition.y + model.ball.height / 2 && paddle.y + paddle.height > model.ball.y - model.ball.height / 2) { // Überprüfen, ob der Ball das Paddle berührt und ob der Ball sich in der Höhe des Paddles befindet. / 2 damit dieser Kollisionsfall nicht in extremfällen eintritt die bei einer niedrigen Renderrate Visuell sehr unwahrscheinlich erscheinen
-            model.ballVelocity.x *= -1.0f;                // x-Richtung umkehren
-            model.ball.x = model.tempBallPosition.x;      // ball zurücksetzen, da es sein kann, das durch unterschiedliche delta-Werte der Ball nach der nächsten Ballbewegung immernoch im Paddle wäre
-            }
-        else if (model.ball.overlaps(paddle)){           // Überprüfen, ob der Ball das Paddle berührt (nun kann dies nurnoch der Fall sein, wenn der Ball sich außerhalb der Höhe des Paddles befindet). Wie die Paddlebewegung (falls das Paddle sich bewegt) damit interagiert ist in der Methode isPaddleNowOverBall() geregelt
-            model.ballVelocity.y *= -1.0f;               // y-Richtung umkehren
-            model.ball.y = model.tempBallPosition.y;     // ball zurücksetzen, da es sein kann, das durch unterschiedliche delta-Werte der Ball nach der nächsten Ballbewegung immernoch im Paddle wäre
-        }
-    }
-
     public void modelwerteInitialisieren(){
         model.paddleA.setSize(20, 100);
         model.paddleB.setSize(20, 100);
@@ -93,6 +91,7 @@ public class Controller {
         resetBall(); // Ball zurücksetzen
     }
     private void resetBall() {
+        model.lastCollidedPaddle = 0; // Letztes Paddle zurücksetzen, damit der Ball nicht sofort wieder zurückprallt
         // Set the ball to the center of the screen and reset its velocity after a point is scored or the ball goes out of bounds
         model.ball.setPosition(model.screenWidth/2, model.screenHeight/2);  // x,y Ball in die Mitte setzen
         model.ballVelocity.set((float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f, (float)(((int)(Math.random() * 2)) * 2 - 1) * 200.0f + (float)Math.random() * 100.0f - 50.0f);  // Ballgeschwindigkeit zurücksetzen

--- a/core/src/main/java/io/github/cpaech/charlie/Model.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Model.java
@@ -13,6 +13,7 @@ public class Model {
     public Vector2 ballVelocity = new Vector2();
     public int scoreA = 0;
     public int scoreB = 0;
+    Vector2 tempBallPosition = new Vector2(0, 0); // Hier wird die Position des Balls bevor der Bewegung peichern, um diese bei einer Kollisionen zurückzusetzen.
     public int paddleSpeed = 300; // Geschwindigkeit der Paddles in Pixel pro Sekunde
     public float[] backgroundColor = {0.15f, 0.15f, 0.2f, 1f};
 }

--- a/core/src/main/java/io/github/cpaech/charlie/Model.java
+++ b/core/src/main/java/io/github/cpaech/charlie/Model.java
@@ -11,6 +11,7 @@ public class Model {
     public Rectangle paddleB = new Rectangle();
     public Rectangle ball = new Rectangle();
     public Vector2 ballVelocity = new Vector2();
+    public int lastCollidedPaddle = 0; //0 = none; 1 = paddle A, 2 = paddle B; this is used to determine which paddle was last hit by the ball, so that the ball can be moved back to its position before the collision if it hits the paddle again.
     public int scoreA = 0;
     public int scoreB = 0;
     Vector2 tempBallPosition = new Vector2(0, 0); // Hier wird die Position des Balls bevor der Bewegung peichern, um diese bei einer Kollisionen zurückzusetzen.


### PR DESCRIPTION
Das ist ein neuer Ansatz zur Collisionsüberprüfung. Bei der Collision mit dem Paddle wird die Richtung des Balles zwangsweise umgekehrt und jede weitere Collision mit dem gleichen Paddle wird ignoriert, das sieht zwar nicht immer gut aus, ist aber durchaus zuverlässig.
fixes #54 